### PR TITLE
fix(listing sorting): available options duplicated

### DIFF
--- a/middleware/listing/sorting/decoder.go
+++ b/middleware/listing/sorting/decoder.go
@@ -59,5 +59,9 @@ func paramsInAvailable(sortKey string, available []Sort) *Sort {
 
 func (dec *Decoder) fillDefaults(s *Sorting) {
 	s.Available = dec.criteria
-	s.Sort = dec.defaultCriteria
+	// fix: avoid override defaultCriteria values when change Sorting
+	if dec.defaultCriteria != nil {
+		sort := *dec.defaultCriteria
+		s.Sort = &sort
+	}
 }


### PR DESCRIPTION
When a sort criteria was selected by query params and it was not the default them override available options