### PR TITLE
feat: handler the catched error by internal error middleware by a optional func

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Name | Description
 Logger | Logs the start and end of each request with the elapsed processing time.
 RequestID | Injects a request ID into the context of each request.
 Recovery | Gracefully absorb panics and prints the stack trace.
-InternalError | Intercept responses to verify if his status code is >= 500. If status is >= 500, it'll response with a [default error](#InternalErrMsg). IT allows to response with the same error without disclosure internal information, also the real error is logged.
+InternalError | Intercept responses to verify if his status code is >= 500. If status is >= 500, it'll response with a [default error](#InternalErrMsg). It allows to response with the same error without disclosure internal information, also log real error (default callback implementation. Check `InternalErrCallback` func to override it).
 
 ### Auxiliary middleware
 
@@ -194,6 +194,12 @@ Represent the message returned to the user when a http 500 error is caught by th
 Default `looks like something went wrong`.
 
 - `InternalErrMsg(msg string)` set the message returned to the user when catch a 500 status error.
+
+### InternalErrCallback
+
+Callback function to handler the real error catched by InternalError middleware.
+
+- `InternalErrCallback(f func(int, io.Reader))` sets the callback function when internal error middleware catch a 500 error.
 
 ### DisableInternalErrorMiddleware
 

--- a/bastion.go
+++ b/bastion.go
@@ -59,10 +59,12 @@ func New(opts ...Opt) *Bastion {
 		app.DisableProfiler = true
 		app.LoggerLevel = ErrorLevel
 	}
-
 	l, err := getLogger(app.LoggerOutput, !app.DisablePrettyLogging, app.LoggerLevel)
 	if err != nil {
 		panic(err)
+	}
+	if app.internalErrorCallback == nil {
+		app.internalErrorCallback = defaultInternalErrCallbackFn(*l)
 	}
 	app.r = router(app.Options, *l)
 	app.Mux = chi.NewMux()
@@ -106,7 +108,7 @@ func router(opts Options, l zerolog.Logger) *chi.Mux {
 	if !opts.DisableInternalErrorMiddleware {
 		internalErr := middleware.InternalError(
 			middleware.InternalErrMsg(errors.New(opts.InternalErrMsg)),
-			middleware.InternalErrLoggerOutput(opts.LoggerOutput),
+			middleware.InternalErrCallback(opts.internalErrorCallback),
 		)
 		mux.Use(internalErr)
 	}

--- a/middleware/README.md
+++ b/middleware/README.md
@@ -34,18 +34,21 @@ func main() {
 ## InternalError
 InternalError intercept responses to verify their status and handle the error. It gets the response code and 
 if it's >= 500 handles the error with a default error message without disclosure internal information. 
-The real error keeps logged.
+The real error can be handled through the callback function `InternalErrCallback`.
 
 ### Options 
 - `InternalErrMsg(s string)` set default error message to be sent. Default "looks like something went wrong".
-- `InternalErrLoggerOutput(w io.Writer)` set the logger output writer. Default `os.Stdout`.
+- `InternalErrCallback(f func(int, io.Reader))` sets the callback function when internal error middleware catch a 500 error.
 
 ```go
 package main
 
 import (
+	"bytes"
 	"errors"
-	
+	"fmt"
+	"io"
+
 	"github.com/ifreddyrondon/bastion/middleware"
 )
 
@@ -57,6 +60,15 @@ func main() {
 	middleware.InternalError(
 		middleware.InternalErrMsg(errors.New("well, this is awkward")),
 	)
+
+	// handler error 
+	handlerErr := func(code int, r io.Reader) {
+		fmt.Printf("code: %v\n", code)
+		var buf bytes.Buffer
+		buf.ReadFrom(r)
+		fmt.Printf(buf.String())
+	}
+	middleware.InternalError(middleware.InternalErrCallback(handlerErr))
 }
 ```
 


### PR DESCRIPTION
- remove InternalErrLoggerOutput option.
- add InternalErrCallback option.